### PR TITLE
10 Bump Core JS version, add Github Action to run test on PR

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,0 +1,21 @@
+name: 'Run tests'
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'Install Node'
+        uses: actions/setup-node@v2
+        with:
+          node-version: '>16.14'
+      - name: 'Install dependencies'
+        run: npm install
+      - name: 'Run tests & report coverage'
+        uses: mattallty/jest-github-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.18",
       "dependencies": {
         "@anymod/core": "^0.1.51",
-        "@userfront/core": "^0.4.7",
+        "@userfront/core": "^0.5.0",
         "compare-versions": "^6.0.0-rc.1"
       },
       "devDependencies": {
@@ -2833,9 +2833,9 @@
       "dev": true
     },
     "node_modules/@userfront/core": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@userfront/core/-/core-0.4.7.tgz",
-      "integrity": "sha512-W29jEC3lkNP5jQx6ssRBebNboyhotGurkJxAcrMluCl1yCcZ+YSp16HUIxBj+Q+x3d+T2bfOQJnUALdHxUi/Dg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@userfront/core/-/core-0.5.0.tgz",
+      "integrity": "sha512-Kr+K/1nN7+kAHLELfFrPmbsGFn+TzywD7Oq/198Y95B7KNQzqz5DPhIXUVZ1CfGbZ0Vv83Bmx/Q4WYCe14uVMA==",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"
@@ -15160,9 +15160,9 @@
       "dev": true
     },
     "@userfront/core": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@userfront/core/-/core-0.4.7.tgz",
-      "integrity": "sha512-W29jEC3lkNP5jQx6ssRBebNboyhotGurkJxAcrMluCl1yCcZ+YSp16HUIxBj+Q+x3d+T2bfOQJnUALdHxUi/Dg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@userfront/core/-/core-0.5.0.tgz",
+      "integrity": "sha512-Kr+K/1nN7+kAHLELfFrPmbsGFn+TzywD7Oq/198Y95B7KNQzqz5DPhIXUVZ1CfGbZ0Vv83Bmx/Q4WYCe14uVMA==",
       "requires": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/userfront/userfront-vue#readme",
   "dependencies": {
     "@anymod/core": "^0.1.51",
-    "@userfront/core": "^0.4.7",
+    "@userfront/core": "^0.5.0",
     "compare-versions": "^6.0.0-rc.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/vue",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Userfront Vue binding",
   "source": "src/index.js",
   "main": "build/userfront-vue.js",


### PR DESCRIPTION
Glance
Closes #10

- Bump Core JS version to `0.5.0`
- Bump own version to `0.1.19`
- Add Github Action to run the test suite on PR to `main` (have been opportunistically adding this everywhere)